### PR TITLE
Fix: Oprava logiky rankingu pro správné zpracování stejných cen

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Po instalaci budete mít k dispozici:
   - Stav: Číslo 1-96 (1 = nejlevnější, 96 = nejdražší)
   - Atributy: `today_rankings`, `tomorrow_rankings` (mapování časů na ranky)
   - **Použití**: Umožňuje jednoduché automatizace typu "prodávej el. při ranku >= 92" (top 5 nejdražších bloků)
+  - **Poznámka**: Bloky se stejnou cenou mají stejný rank (standard ranking)
 
 ### Statistické sensory
 - `sensor.sk_spot_daily_min` - Minimální cena dnes
@@ -367,6 +368,12 @@ Sensor `sk_spot_current_rank` obsahuje atributy:
 - `tomorrow_rankings`: Slovník všech zítřejších ranků (pokud dostupné)
 
 Umožňuje plánování: "Zítra v 10:00 bude rank 15, ideální pro nabíjení"
+
+### 5. Standard ranking pro stejné ceny
+Pokud mají bloky stejnou cenu, mají stejný rank:
+- Například: 2 bloky s cenou 100 EUR → oba mají rank 1
+- Další blok s cenou 150 EUR → má rank 3 (přeskočí rank 2)
+- Výhoda: Pokud je více bloků s nejnižší cenou, všechny budou mít rank 1
 
 ## Technické detaily
 

--- a/custom_components/sk_spot/binary_sensor.py
+++ b/custom_components/sk_spot/binary_sensor.py
@@ -544,15 +544,14 @@ def get_current_rank(coordinator):
     if current_idx not in today_prices:
         return None
 
-    # Seřaď všechny dnešní ceny vzestupně
-    sorted_prices = sorted(today_prices.items(), key=lambda x: x[1])
+    current_price = today_prices[current_idx]
 
-    # Najdi pozici aktuálního indexu v seřazeném seznamu
-    for rank, (idx, price) in enumerate(sorted_prices, start=1):
-        if idx == current_idx:
-            return rank
+    # Spočítej kolik bloků má nižší cenu (standard ranking)
+    # Pokud je více bloků se stejnou cenou, všechny mají stejný rank
+    lower_count = sum(1 for price in today_prices.values() if price < current_price)
 
-    return None
+    # Rank je počet bloků s nižší cenou + 1
+    return lower_count + 1
 
 
 class SKSpotInTop5ExpensiveSensor(CoordinatorEntity, BinarySensorEntity):


### PR DESCRIPTION
Problém:
- Původní logika používala prostou pozici v seřazeném seznamu
- Bloky se stejnou cenou měly různý rank (nesprávné!)
- Například: 2 bloky s cenou 100 EUR měly ranky 1 a 2

Řešení:
- Implementace standard rankingu
- Bloky se stejnou cenou nyní mají stejný rank
- Příklad: 2 bloky s cenou 100 EUR → oba mají rank 1
- Další blok s cenou 150 EUR → má rank 3 (přeskočí rank 2)

Výhody:
- Správné zobrazení rankingu pro duplicitní ceny
- Pokud je více bloků s nejnižší cenou, všechny mají rank 1
- Konzistentní chování napříč všemi sensory

Změny:
- sensor.py: SKSpotCurrentRankSensor.native_value()
- sensor.py: Atributy today_rankings a tomorrow_rankings
- binary_sensor.py: get_current_rank()
- README.md: Přidán popis standard rankingu